### PR TITLE
fixing yarn package

### DIFF
--- a/extension/build-util/prepare-extension-config.js
+++ b/extension/build-util/prepare-extension-config.js
@@ -1,5 +1,4 @@
 import * as fs from 'node:fs';
-console.log("HI");
 
 var data = fs.readFileSync('package.json', 'utf-8');
 var newValue = data.replace('"main": "./pack/src/extension.cjs"', '"main": "./pack/src/extension.js"');

--- a/extension/build-util/prepare-extension-config.js
+++ b/extension/build-util/prepare-extension-config.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 console.log("HI");
 
 var data = fs.readFileSync('filelist.txt', 'utf-8');
-var newValue = data.replace(/^\./gim, 'myString');
+var newValue = data.replace('"main": "./pack/src/extension.cjs"', '"main": "./pack/src/extension.js"');
 fs.writeFileSync('filelistSync.txt', newValue, 'utf-8');
 
 console.log('Bad magic');

--- a/extension/build-util/prepare-extension-config.js
+++ b/extension/build-util/prepare-extension-config.js
@@ -1,8 +1,8 @@
-var fs = require('fs');
+import * as fs from 'node:fs';
 console.log("HI");
 
-var data = fs.readFileSync('filelist.txt', 'utf-8');
+var data = fs.readFileSync('package.json', 'utf-8');
 var newValue = data.replace('"main": "./pack/src/extension.cjs"', '"main": "./pack/src/extension.js"');
-fs.writeFileSync('filelistSync.txt', newValue, 'utf-8');
+fs.writeFileSync('package.json', newValue, 'utf-8');
 
 console.log('Bad magic');

--- a/extension/build-util/prepare-extension-config.js
+++ b/extension/build-util/prepare-extension-config.js
@@ -1,0 +1,8 @@
+var fs = require('fs');
+console.log("HI");
+
+var data = fs.readFileSync('filelist.txt', 'utf-8');
+var newValue = data.replace(/^\./gim, 'myString');
+fs.writeFileSync('filelistSync.txt', newValue, 'utf-8');
+
+console.log('Bad magic');

--- a/extension/package.json
+++ b/extension/package.json
@@ -586,7 +586,7 @@
         "lint": "eslint .",
         "build": "yarn run langium:generate && tsc -b src src-diagram-snippets src-language-server src-webview src-context-table && node esbuild.mjs",
         "watch": "webpack --watch",
-        "package": "vsce package --yarn -o pasta.vsix",
+        "package": "node build-util/prepare-extension-config.js && vsce package --yarn -o pasta.vsix",
         "predistribute": "yarn run package",
         "distribute": "yarn run distribute:vsce && yarn run distribute:ovsx",
         "distribute:vsce": "vsce publish --yarn --packagePath pasta.vsix",

--- a/extension/package.json
+++ b/extension/package.json
@@ -544,7 +544,7 @@
         "src-webview",
         "pack"
     ],
-    "main": "./pack/src/extension.js",
+    "main": "./pack/src/extension.cjs",
     "dependencies": {
         "langium": "^3.0.0",
         "langium-sprotty": "^3.0.0",


### PR DESCRIPTION
for packaging the extension the "Main" attribute in package.json must be "extension.js" while for local execution of the extension it must be "extion.cjs". Hence, this workaround replaces the value before executing the yarn package command.