### PR TITLE
Jep/utility

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -133,13 +133,13 @@
                 "category": "STPA Checks"
             },
             {
-                "command": "pasta.stpa.checks.setCheckSafetyRequirementsForUCAs",
-                "title": "Set the safety requirements for UCA check",
+                "command": "pasta.stpa.checks.setCheckSafetyRequirementsForScenarios",
+                "title": "Set the safety requirements for scenarios check",
                 "category": "STPA Checks"
             },
             {
-                "command": "pasta.stpa.checks.unsetCheckSafetyRequirementsForUCAs",
-                "title": "✓ Set the safety requirements for UCA check",
+                "command": "pasta.stpa.checks.unsetCheckSafetyRequirementsForScenarios",
+                "title": "✓ Set the safety requirements for scenarios check",
                 "category": "STPA Checks"
             },
             {
@@ -261,12 +261,12 @@
                     "when": "editorLangId == 'stpa' && checkScenariosForUCAs == true"
                 },
                 {
-                    "command": "pasta.stpa.checks.setCheckSafetyRequirementsForUCAs",
-                    "when": "editorLangId == 'stpa' && checkSafetyRequirementsForUCAs == false"
+                    "command": "pasta.stpa.checks.setCheckSafetyRequirementsForScenarios",
+                    "when": "editorLangId == 'stpa' && checkSafetyRequirementsForScenarios == false"
                 },
                 {
-                    "command": "pasta.stpa.checks.unsetCheckSafetyRequirementsForUCAs",
-                    "when": "editorLangId == 'stpa' && checkSafetyRequirementsForUCAs == true"
+                    "command": "pasta.stpa.checks.unsetCheckSafetyRequirementsForScenarios",
+                    "when": "editorLangId == 'stpa' && checkSafetyRequirementsForScenarios == true"
                 },
                 {
                     "command": "pasta.stpa.checks.setCheckMissingFeedback",
@@ -409,15 +409,15 @@
                     "group": "checks@3"
                 },
                 {
-                    "command": "pasta.stpa.checks.setCheckSafetyRequirementsForUCAs",
+                    "command": "pasta.stpa.checks.setCheckSafetyRequirementsForScenarios",
                     "title": "editorLangId == 'stpa'",
-                    "when": "editorLangId == 'stpa' && pasta.checkSafetyRequirementsForUCAs == false",
+                    "when": "editorLangId == 'stpa' && pasta.checkSafetyRequirementsForScenarios == false",
                     "group": "checks@4"
                 },
                 {
-                    "command": "pasta.stpa.checks.unsetCheckSafetyRequirementsForUCAs",
+                    "command": "pasta.stpa.checks.unsetCheckSafetyRequirementsForScenarios",
                     "title": "editorLangId == 'stpa'",
-                    "when": "editorLangId == 'stpa' && pasta.checkSafetyRequirementsForUCAs == true",
+                    "when": "editorLangId == 'stpa' && pasta.checkSafetyRequirementsForScenarios == true",
                     "group": "checks@4"
                 },
                 {

--- a/extension/src-language-server/stpa/diagram/diagram-controlStructure.ts
+++ b/extension/src-language-server/stpa/diagram/diagram-controlStructure.ts
@@ -73,6 +73,7 @@ export function createControlStructure(
         id: "controlStructure",
         children: CSChildren,
         modelOrder: options.getModelOrder(),
+        showBorder: options.getShowRelationshipGraph(),
     };
 }
 

--- a/extension/src-language-server/stpa/diagram/diagram-relationshipGraph.ts
+++ b/extension/src-language-server/stpa/diagram/diagram-relationshipGraph.ts
@@ -75,6 +75,7 @@ export function createRelationshipGraph(
         id: "relationships",
         children: children,
         modelOrder: options.getModelOrder(),
+        showBorder: options.getShowControlStructure()
     };
 }
 

--- a/extension/src-language-server/stpa/diagram/layout-config.ts
+++ b/extension/src-language-server/stpa/diagram/layout-config.ts
@@ -128,6 +128,7 @@ export class StpaLayoutConfigurator extends DefaultLayoutConfigurator {
             // nodes with many edges are streched
             "org.eclipse.elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
             "org.eclipse.elk.layered.nodePlacement.networkSimplex.nodeFlexibility.default": "NODE_SIZE",
+            "org.eclipse.elk.spacing.portsSurrounding": "[top=10.0,left=10.0,bottom=10.0,right=10.0]",
         };
     }
 

--- a/extension/src-language-server/stpa/diagram/stpa-interfaces.ts
+++ b/extension/src-language-server/stpa/diagram/stpa-interfaces.ts
@@ -20,6 +20,7 @@ import { EdgeType, PortSide, STPAAspect } from "./stpa-model.js";
 
 export interface ParentNode extends SNode {
     modelOrder: boolean;
+    showBorder: boolean;
 }
 
 /**

--- a/extension/src-language-server/stpa/message-handler.ts
+++ b/extension/src-language-server/stpa/message-handler.ts
@@ -217,7 +217,7 @@ export function handleSTPAConfigReset(stpaServices: StpaServices): void {
     validator.checkResponsibilitiesForConstraints = true;
     validator.checkConstraintsForUCAs = true;
     validator.checkScenariosForUCAs = true;
-    validator.checkSafetyRequirementsForUCAs = true;
+    validator.checkSafetyRequirementsForScenarios = true;
     validator.checkMissingFeedback = true;
     // reset synthesis options
     stpaServices.options.SynthesisOptions.resetAll();

--- a/extension/src-language-server/stpa/services/ID-enforcer.ts
+++ b/extension/src-language-server/stpa/services/ID-enforcer.ts
@@ -173,8 +173,10 @@ export class IDEnforcer {
             };
             newRange.end.character = newRange.start.character + modifiedElement.name.length;
             newRange.end.line = newRange.start.line;
+            // add leading zero to the counter if it is less than 10
+            const counter = index < 10 ? "0" + index : index;
             // create the edit
-            const modifiedElementEdit = TextEdit.replace(newRange, prefix + index);
+            const modifiedElementEdit = TextEdit.replace(newRange, prefix + counter);
             edits.push(modifiedElementEdit);
         }
         return edits;
@@ -232,7 +234,9 @@ export class IDEnforcer {
                             const range = elementToRename.$cstNode.range;
                             range.end.character = range.start.character + elementToRename.name.length;
                             range.end.line = range.start.line;
-                            const modifiedElementEdit = TextEdit.replace(range, prefix + (i + 1));
+                            // add leading zero to the counter if it is less than 10
+                            const counter = i + 1 < 10 ? "0" + (i + 1) : i + 1;
+                            const modifiedElementEdit = TextEdit.replace(range, prefix + counter);
                             edits.push(modifiedElementEdit);
                         }
                         // rename references by calling the rename function with the modified element
@@ -322,12 +326,14 @@ export class IDEnforcer {
      */
     protected async renameID(element: elementWithName, prefix: string, counter: number): Promise<TextEdit[]> {
         let edits: TextEdit[] = [];
+        // add leading zero to the counter if it is less than 10
+        const updatedCounter = counter < 10 ? "0" + counter : counter;
         if (element && element.$cstNode) {
             // parameters needed for renaming
             const params: RenameParams = {
                 textDocument: this.currentDocument.textDocument,
                 position: element.$cstNode.range.start,
-                newName: prefix + counter,
+                newName: prefix + updatedCounter,
             };
             // compute the textedits for renaming
             const edit = await this.stpaServices.lsp.RenameProvider!.rename(this.currentDocument, params);
@@ -338,7 +344,7 @@ export class IDEnforcer {
             if ((isHazard(element) || isSystemConstraint(element)) && element.subComponents.length !== 0) {
                 let index = 1;
                 for (const child of element.subComponents) {
-                    edits = edits.concat(await this.renameID(child, prefix + counter + ".", index));
+                    edits = edits.concat(await this.renameID(child, prefix + updatedCounter + ".", index));
                     index++;
                 }
             }

--- a/extension/src-language-server/stpa/services/ID-enforcer.ts
+++ b/extension/src-language-server/stpa/services/ID-enforcer.ts
@@ -17,7 +17,7 @@
 
 import { CstNode, isCompositeCstNode, LangiumDocument } from "langium";
 import { TextDocumentContentChangeEvent } from "vscode";
-import { Range, RenameParams, TextEdit } from "vscode-languageserver";
+import { RenameParams, TextEdit } from "vscode-languageserver";
 import {
     ActionUCAs,
     ControllerConstraint,

--- a/extension/src-language-server/stpa/services/stpa-completion-provider.ts
+++ b/extension/src-language-server/stpa/services/stpa-completion-provider.ts
@@ -134,7 +134,10 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
      * @param acceptor The completion acceptor to add the completion items.
      */
     protected completionForSystemComponent(
-        context: CompletionContext, next: NextFeature, acceptor: CompletionAcceptor): void {
+        context: CompletionContext,
+        next: NextFeature,
+        acceptor: CompletionAcceptor
+    ): void {
         if (next.type === Node && next.property === "name") {
             const generatedText = `Comp {
     hierarchyLevel 0
@@ -302,7 +305,7 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
             const generatedItems = this.generateTextForUCAWithPlainText(
                 context.node as UCA,
                 lastChar,
-                context.node.$containerProperty,
+                context.node.$containerProperty
             );
 
             if (generatedItems.length > 0) {
@@ -361,7 +364,14 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
                     detail: "Inserts the starting text for this UCA.",
                     sortText: "1",
                 };
-                return [tooEarlyItem, tooLateItem];
+                const wrongOrderItem = {
+                    label: "Generate wrong-order UCA Text",
+                    kind: CompletionItemKind.Text,
+                    insertText: `${whitespace}\"${system} provided ${controlAction} in the wrong order TODO\"`,
+                    detail: "Inserts the starting text for this UCA.",
+                    sortText: "1",
+                };
+                return [tooEarlyItem, tooLateItem, wrongOrderItem];
             case "continousUcas":
                 const stoppedTooSoonItem = {
                     label: "Generate stopped-too-soon UCA Text",

--- a/extension/src-language-server/stpa/services/stpa-completion-provider.ts
+++ b/extension/src-language-server/stpa/services/stpa-completion-provider.ts
@@ -298,9 +298,11 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
      */
     protected completionForUCA(context: CompletionContext, next: NextFeature, acceptor: CompletionAcceptor): void {
         if (context.node?.$type === UCA && next.property === "description") {
+            const lastChar = context.document.textDocument.getText().charAt(context.offset - 1);
             const generatedItems = this.generateTextForUCAWithPlainText(
                 context.node as UCA,
-                context.node.$containerProperty
+                lastChar,
+                context.node.$containerProperty,
             );
 
             if (generatedItems.length > 0) {
@@ -315,7 +317,7 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
      * @param property The property in which the UCA is contained. Should be one of "notProvidingUcas", "providingUcas", "wrongTimingUcas", or "continousUcas".
      * @returns completion items for the given UCA.
      */
-    protected generateTextForUCAWithPlainText(uca: UCA, property?: string): CompletionValueItem[] {
+    protected generateTextForUCAWithPlainText(uca: UCA, lastChar: string, property?: string): CompletionValueItem[] {
         const actionUca = uca.$container;
         const system = actionUca.system.ref?.label ?? actionUca.system.$refText;
         let controlAction = `the control action '${actionUca.action.ref?.label}'`;
@@ -323,12 +325,14 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
         if (isVerticalEdge(parent)) {
             controlAction += ` to ${parent.target.ref?.label ?? parent.target.$refText}`;
         }
+        // if the last character is not a whitespace, add one to create space after UCA ID
+        const whitespace = lastChar === " " ? "" : " ";
         switch (property) {
             case "notProvidingUcas":
                 const notProvidedItem = {
                     label: "Generate not provided UCA Text",
                     kind: CompletionItemKind.Text,
-                    insertText: `${system} did not provide ${controlAction}, TODO`,
+                    insertText: `${whitespace}\"${system} did not provide ${controlAction}, TODO\"`,
                     detail: "Inserts the starting text for this UCA.",
                     sortText: "0",
                 };
@@ -337,7 +341,7 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
                 const providedItem = {
                     label: "Generate provided UCA Text",
                     kind: CompletionItemKind.Text,
-                    insertText: `${system} provided ${controlAction}, TODO`,
+                    insertText: `${whitespace}\"${system} provided ${controlAction}, TODO\"`,
                     detail: "Inserts the starting text for this UCA.",
                     sortText: "0",
                 };
@@ -346,14 +350,14 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
                 const tooEarlyItem = {
                     label: "Generate too-early UCA Text",
                     kind: CompletionItemKind.Text,
-                    insertText: `${system} provided ${controlAction} before TODO`,
+                    insertText: `${whitespace}\"${system} provided ${controlAction} before TODO\"`,
                     detail: "Inserts the starting text for this UCA.",
                     sortText: "0",
                 };
                 const tooLateItem = {
                     label: "Generate too-late UCA Text",
                     kind: CompletionItemKind.Text,
-                    insertText: `${system} provided ${controlAction} after TODO`,
+                    insertText: `${whitespace}\"${system} provided ${controlAction} after TODO\"`,
                     detail: "Inserts the starting text for this UCA.",
                     sortText: "1",
                 };
@@ -362,14 +366,14 @@ export class STPACompletionProvider extends DefaultCompletionProvider {
                 const stoppedTooSoonItem = {
                     label: "Generate stopped-too-soon UCA Text",
                     kind: CompletionItemKind.Text,
-                    insertText: `${system} stopped ${controlAction} before TODO`,
+                    insertText: `${whitespace}\"${system} stopped ${controlAction} before TODO\"`,
                     detail: "Inserts the starting text for this UCA.",
                     sortText: "0",
                 };
                 const appliedTooLongItem = {
                     label: "Generate applied-too-long UCA Text",
                     kind: CompletionItemKind.Text,
-                    insertText: `${system} still applied ${controlAction} after TODO`,
+                    insertText: `${whitespace}\"${system} still applied ${controlAction} after TODO\"`,
                     detail: "Inserts the starting text for this UCA.",
                     sortText: "1",
                 };

--- a/extension/src-language-server/stpa/services/stpa-scopeProvider.ts
+++ b/extension/src-language-server/stpa/services/stpa-scopeProvider.ts
@@ -72,6 +72,7 @@ export class StpaScopeProvider extends DefaultScopeProvider {
     private VARIABLE_TYPE = Variable;
     private NODE_TYPE = Node;
     private VARIABLE_VALUE_TYPE = VariableValue;
+    private LOSS_SCENARIO_TYPE = LossScenario;
 
     constructor(services: StpaServices) {
         super(services);
@@ -90,7 +91,7 @@ export class StpaScopeProvider extends DefaultScopeProvider {
         if (precomputed && model) {
             // determine the scope for the different aspects & reference types
             if (
-                (isControllerConstraint(node) || isLossScenario(node) || isSafetyConstraint(node)) &&
+                (isControllerConstraint(node) || isLossScenario(node)) &&
                 (referenceType === this.UCA_TYPE || referenceType === this.CONTEXT_TYPE)
             ) {
                 return this.getUCAs(model, precomputed);
@@ -120,6 +121,11 @@ export class StpaScopeProvider extends DefaultScopeProvider {
                 referenceType === this.NODE_TYPE
             ) {
                 return this.getNodes(node, precomputed);
+            } else if (isSafetyConstraint(node)) {
+                const UCADescriptions = this.getUCAs(model, precomputed).getAllElements();
+                const hazardDescriptions = this.getHazards(model, precomputed).getAllElements();
+                const lossScenarioDescriptions = this.getStandardScope(node, this.LOSS_SCENARIO_TYPE, precomputed).getAllElements();
+                return this.descriptionsToScope([...UCADescriptions, ...hazardDescriptions, ...lossScenarioDescriptions]);
             } else {
                 return this.getStandardScope(node, referenceType, precomputed);
             }

--- a/extension/src-language-server/stpa/services/stpa-scopeProvider.ts
+++ b/extension/src-language-server/stpa/services/stpa-scopeProvider.ts
@@ -210,7 +210,11 @@ export class StpaScopeProvider extends DefaultScopeProvider {
             }
             return graph as Graph;
         } else if (isSystemResponsibilities(node) || isActionUCAs(node) || isRule(node) || isDCARule(node)) {
-            return node.$container.controlStructure;
+            let parent: VerticalEdge | SystemResponsibilities | ActionUCAs | Rule | DCARule | Model = node;
+            while (parent && !isModel(parent)) {
+                parent = parent.$container;
+            }
+            return parent?.controlStructure;
         }
     }
 

--- a/extension/src-language-server/stpa/services/stpa-validator.ts
+++ b/extension/src-language-server/stpa/services/stpa-validator.ts
@@ -68,7 +68,7 @@ export class StpaValidator {
     checkScenariosForUCAs = true;
 
     /** Boolean option to toggle the check whether all UCAs are covered by safety requirements. */
-    checkSafetyRequirementsForUCAs = true;
+    checkSafetyRequirementsForScenarios = true;
 
     /** Boolean option to toggle the check whether system components are missing feedback in the control structure. */
     checkMissingFeedback = true;
@@ -133,10 +133,6 @@ export class StpaValidator {
         const scenarioRefs: (string | undefined)[] = this.checkScenariosForUCAs
             ? model.scenarios.map(scenario => scenario.uca?.ref?.name)
             : [];
-        // const safetyRequirementsRefs = this.checkSafetyRequirementsForUCAs
-        //     ? this.collectReferences(model.safetyCons)
-        //     : new Set<string>();
-        // check if ucas are referenced by the other aspects
         const nodesToCheck = [...ucas, ...contexts];
         for (const node of nodesToCheck) {
             if (!constraintsRefs.has(node.name)) {
@@ -145,12 +141,16 @@ export class StpaValidator {
             if (!scenarioRefs.includes(node.name)) {
                 accept("warning", "This element is not referenced by any scenario", { node: node, property: "name" });
             }
-            // if (!safetyRequirementsRefs.has(node.name)) {
-            //     accept("warning", "This element is not referenced by any safety requirement", {
-            //         node: node,
-            //         property: "name",
-            //     });
-            // }
+        }
+
+        // check that all scenarios are referenced by at least one safety requirement
+        if (this.checkSafetyRequirementsForScenarios) {
+            this.checkThatElementsAreReferenced(
+                model.scenarios,
+                model.safetyCons,
+                "This scenario is not referenced by any safety requirement",
+                accept
+            );
         }
 
         // collect elements that have an identifier and should be referenced

--- a/extension/src-language-server/stpa/services/stpa-validator.ts
+++ b/extension/src-language-server/stpa/services/stpa-validator.ts
@@ -133,9 +133,9 @@ export class StpaValidator {
         const scenarioRefs: (string | undefined)[] = this.checkScenariosForUCAs
             ? model.scenarios.map(scenario => scenario.uca?.ref?.name)
             : [];
-        const safetyRequirementsRefs = this.checkSafetyRequirementsForUCAs
-            ? this.collectReferences(model.safetyCons)
-            : new Set<string>();
+        // const safetyRequirementsRefs = this.checkSafetyRequirementsForUCAs
+        //     ? this.collectReferences(model.safetyCons)
+        //     : new Set<string>();
         // check if ucas are referenced by the other aspects
         const nodesToCheck = [...ucas, ...contexts];
         for (const node of nodesToCheck) {
@@ -145,12 +145,12 @@ export class StpaValidator {
             if (!scenarioRefs.includes(node.name)) {
                 accept("warning", "This element is not referenced by any scenario", { node: node, property: "name" });
             }
-            if (!safetyRequirementsRefs.has(node.name)) {
-                accept("warning", "This element is not referenced by any safety requirement", {
-                    node: node,
-                    property: "name",
-                });
-            }
+            // if (!safetyRequirementsRefs.has(node.name)) {
+            //     accept("warning", "This element is not referenced by any safety requirement", {
+            //         node: node,
+            //         property: "name",
+            //     });
+            // }
         }
 
         // collect elements that have an identifier and should be referenced

--- a/extension/src-language-server/stpa/stpa.langium
+++ b/extension/src-language-server/stpa/stpa.langium
@@ -152,7 +152,7 @@ HazardList:
     '[' refs+=[Hazard:SubID] (',' refs+=[Hazard:SubID])*']';
 
 SafetyConstraint:
-    name=ID description=STRING '['refs+=[LossScenario] (',' refs+=[LossScenario])*']';
+    name=ID description=STRING '[' (refs+=[LossScenario] | refs+=[Hazard] | refs+=[UCA]) (',' (refs+=[LossScenario] | refs+=[Hazard] | refs+=[UCA]) )* ']';
 
 NotProvided returns string:
     'not-provided';

--- a/extension/src-language-server/stpa/stpa.langium
+++ b/extension/src-language-server/stpa/stpa.langium
@@ -113,8 +113,8 @@ ActionUCAs:
     action=[Command] '{'
         'notProviding' '{'notProvidingUcas+=UCA*'}'
         'providing' '{'providingUcas+=UCA*'}'
-        'tooEarly/Late' '{'wrongTimingUcas+=UCA*'}'
-        'stoppedTooSoon' '{'continousUcas+=UCA*'}'
+        'tooEarlyOrLateOrWrongOrder' '{'wrongTimingUcas+=UCA*'}'
+        'stoppedTooSoonOrLate' '{'continousUcas+=UCA*'}'
     '}';
 
 UCA:

--- a/extension/src-language-server/utils.ts
+++ b/extension/src-language-server/utils.ts
@@ -125,8 +125,8 @@ export function updateValidationChecks(options: Record<string, any>, validator: 
             case "checkScenariosForUCAs":
                 validator.checkScenariosForUCAs = value;
                 break;
-            case "checkSafetyRequirementsForUCAs":
-                validator.checkSafetyRequirementsForUCAs = value;
+            case "checkSafetyRequirementsForScenarios":
+                validator.checkSafetyRequirementsForScenarios = value;
                 break;
             case "checkMissingFeedback":
                 validator.checkMissingFeedback = value;

--- a/extension/src-webview/di.config.ts
+++ b/extension/src-webview/di.config.ts
@@ -98,6 +98,7 @@ import {
     HeaderLabelView,
     IntermediateEdgeView,
     InvisibleNodeView,
+    ParentNodeView,
     PolylineArrowEdgeView,
     PortView,
     STPAGraphView,
@@ -137,7 +138,7 @@ const pastaDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) =
     configureModelElement(context, DUMMY_NODE_TYPE, CSNode, CSNodeView);
     configureModelElement(context, CS_NODE_TYPE, CSNode, CSNodeView);
     configureModelElement(context, STPA_NODE_TYPE, STPANode, STPANodeView);
-    configureModelElement(context, PARENT_TYPE, ParentNode, CSNodeView);
+    configureModelElement(context, PARENT_TYPE, ParentNode, ParentNodeView);
     configureModelElement(context, STPA_EDGE_TYPE, STPAEdge, PolylineArrowEdgeView);
     configureModelElement(context, STPA_INTERMEDIATE_EDGE_TYPE, STPAEdge, IntermediateEdgeView);
     configureModelElement(context, CS_INTERMEDIATE_EDGE_TYPE, CSEdge, IntermediateEdgeView);

--- a/extension/src-webview/stpa/stpa-model.ts
+++ b/extension/src-webview/stpa/stpa-model.ts
@@ -37,6 +37,7 @@ export const EDGE_LABEL_TYPE = 'label:xref';
 
 export class ParentNode extends SNodeImpl {
     modelOrder: boolean;
+    showBorder: boolean;
     static readonly DEFAULT_FEATURES = [connectableFeature, selectFeature, layoutContainerFeature, fadeFeature];
 }
 

--- a/extension/src-webview/stpa/stpa-views.tsx
+++ b/extension/src-webview/stpa/stpa-views.tsx
@@ -25,7 +25,7 @@ import { ColorStyleOption, DifferentFormsOption, FeedbackStyleOption, RenderOpti
 import { SendModelRendererAction } from '../snippets/actions';
 import { renderCollapseIcon, renderDiamond, renderEllipse, renderExpandIcon, renderHexagon, renderMirroredTriangle, renderOval, renderPentagon, renderRectangle, renderRectangleForNode, renderRoundedRectangle, renderTrapez, renderTriangle } from '../views-rendering';
 import { collectAllChildren } from './helper-methods';
-import { CSEdge, CSNode, CS_EDGE_TYPE, CS_INTERMEDIATE_EDGE_TYPE, CS_NODE_TYPE, EdgeType, STPAAspect, STPAEdge, STPANode, STPA_EDGE_TYPE, STPA_INTERMEDIATE_EDGE_TYPE } from './stpa-model';
+import { CSEdge, CSNode, CS_EDGE_TYPE, CS_INTERMEDIATE_EDGE_TYPE, CS_NODE_TYPE, EdgeType, ParentNode, STPAAspect, STPAEdge, STPANode, STPA_EDGE_TYPE, STPA_INTERMEDIATE_EDGE_TYPE } from './stpa-model';
 
 /** Determines if path/aspect highlighting is currently on. */
 let highlighting: boolean;
@@ -274,6 +274,23 @@ export class CSNodeView extends RectangularNodeView {
         }
     }
 }
+
+@injectable()
+export class ParentNodeView extends CSNodeView {
+
+    @inject(DISymbol.RenderOptionsRegistry) renderOptionsRegistry: RenderOptionsRegistry;
+
+    render(node: ParentNode, context: RenderingContext): VNode {
+        if (node.showBorder) {
+            return super.render(node, context);
+        } else {
+            return <g>
+                {context.renderChildren(node)}
+            </g>;
+        }
+    }
+}
+
 
 @injectable()
 export class InvisibleNodeView extends RectangularNodeView {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -44,7 +44,7 @@ const validationContexts = [
     "checkResponsibilitiesForConstraints",
     "checkConstraintsForUCAs",
     "checkScenariosForUCAs",
-    "checkSafetyRequirementsForUCAs",
+    "checkSafetyRequirementsForScenarios",
     "checkMissingFeedback",
 ];
 
@@ -196,7 +196,7 @@ function resetContextForStorageOptions(): void {
     vscode.commands.executeCommand("setContext", "pasta.checkResponsibilitiesForConstraints", true);
     vscode.commands.executeCommand("setContext", "pasta.checkConstraintsForUCAs", true);
     vscode.commands.executeCommand("setContext", "pasta.checkScenariosForUCAs", true);
-    vscode.commands.executeCommand("setContext", "pasta.checkSafetyRequirementsForUCAs", true);
+    vscode.commands.executeCommand("setContext", "pasta.checkSafetyRequirementsForScenarios", true);
     vscode.commands.executeCommand("setContext", "pasta.checkMissingFeedback", true);
     vscode.commands.executeCommand("setContext", "pasta.generateIDs", true);
 }


### PR DESCRIPTION
Small Improvements:
* borders around graphs only if both are visible
* leading zeros for component IDs (fixes #74)
* adjusted UCA keywords (fixes #79)
* more precise warnings for not referenced components (fixes #80)
* fixed autocomplete for node references in Responsibilities and UCAs (fixes #81)
* added quotes and optional whitespace for automated UCA descriptions (fixes #83)
* added automated UCA description for type "wrong order" (fixes #84)
* SafetyRequirements can reference UCAs and Hazards now as well (fixes #88)
* added check that a scenario is referenced by a safety requirement
* removed check that a UCA is referenced by a safety requirement