### PR TITLE
Added option for tighter spacing of edges

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -223,6 +223,7 @@ The extension provides several diagram options to adjust the diagram.
     * The "highlight" option determines whether to display the description of a node when it is clicked on (and the descriptions of connected nodes) 
 * Filter UCA by Control Action: The UCAs can be filtered such that only UCAs for a certain control action are shown making the diagram smaller and clearer.
 * Show x: When selected the specified graph/aspect is shown, otherwise it is hidden.
+* Relationship Edges: Removes the spacing between edges, so that the diagram is arranged more closely together and initially grays the edges out.
 
 
 ### FTA 

--- a/extension/src-language-server/stpa/diagram/diagram-controlStructure.ts
+++ b/extension/src-language-server/stpa/diagram/diagram-controlStructure.ts
@@ -73,6 +73,7 @@ export function createControlStructure(
         id: "controlStructure",
         children: CSChildren,
         modelOrder: options.getModelOrder(),
+        showEdges: true,
         showBorder: options.getShowRelationshipGraph(),
     };
 }

--- a/extension/src-language-server/stpa/diagram/diagram-relationshipGraph.ts
+++ b/extension/src-language-server/stpa/diagram/diagram-relationshipGraph.ts
@@ -75,7 +75,8 @@ export function createRelationshipGraph(
         id: "relationships",
         children: children,
         modelOrder: options.getModelOrder(),
-        showBorder: options.getShowControlStructure()
+        showBorder: options.getShowControlStructure(),
+        showEdges: options.getShowEdges(),
     };
 }
 

--- a/extension/src-language-server/stpa/diagram/layout-config.ts
+++ b/extension/src-language-server/stpa/diagram/layout-config.ts
@@ -47,11 +47,12 @@ export class StpaLayoutConfigurator extends DefaultLayoutConfigurator {
         // priority is used to determine the order of the nodes
         let priority = "";
         const csParent = snode.children?.find(child => child.type === CS_NODE_TYPE);
+        const relationshipNode = snode.children?.find(child => child.type === STPA_NODE_TYPE);
         if (csParent) {
             // options for the control structure
             direction = "DOWN";
             priority = "1";
-        } else if (snode.children?.find(child => child.type === STPA_NODE_TYPE)) {
+        } else if (relationshipNode) {
             // options for the STPA graph
             direction = "UP";
             priority = "0";
@@ -69,6 +70,13 @@ export class StpaLayoutConfigurator extends DefaultLayoutConfigurator {
             "org.eclipse.elk.spacing.portsSurrounding": "[top=10.0,left=10.0,bottom=10.0,right=10.0]",
             "org.eclipse.elk.priority": priority,
         };
+        // TODO: only do this when corresponding option is set
+        if (!snode.showEdges) {
+            options["org.eclipse.elk.layered.spacing.edgeEdgeBetweenLayers"] = "0";
+            options["org.eclipse.elk.layered.nodePlacement.networkSimplex.nodeFlexibility.default"] = "NONE";
+        } else if (relationshipNode) {
+            options["org.eclipse.elk.layered.spacing.edgeEdgeBetweenLayers"] = "6";
+        }
 
         // model order is used to determine the order of the children
         if (snode.modelOrder) {

--- a/extension/src-language-server/stpa/diagram/stpa-interfaces.ts
+++ b/extension/src-language-server/stpa/diagram/stpa-interfaces.ts
@@ -21,6 +21,7 @@ import { EdgeType, PortSide, STPAAspect } from "./stpa-model.js";
 export interface ParentNode extends SNode {
     modelOrder: boolean;
     showBorder: boolean;
+    showEdges: boolean;
 }
 
 /**

--- a/extension/src-language-server/stpa/diagram/stpa-synthesis-options.ts
+++ b/extension/src-language-server/stpa/diagram/stpa-synthesis-options.ts
@@ -317,7 +317,7 @@ const showScenariosWithHazardsOption: ValuedSynthesisOption = {
 };
 
 /**
- * Boolean option to toggle the visualization of the relationship graph.
+ * Boolean option to toggle the visualization of the edges in the relationship graph.
  */
 const showEdgesOption: ValuedSynthesisOption = {
     synthesisOption: {

--- a/extension/src-language-server/stpa/diagram/stpa-synthesis-options.ts
+++ b/extension/src-language-server/stpa/diagram/stpa-synthesis-options.ts
@@ -44,6 +44,7 @@ const showControlStructureID = "showControlStructure";
 const showProcessModelsID = "showProcessModels";
 const showUnclosedFeedbackLoopsID = "showUnclosedFeedbackLoops";
 const showRelationshipGraphID = "showRelationshipGraph";
+const showEdgesID = "showEdges";
 
 /**
  * Category for filtering options.
@@ -286,6 +287,22 @@ const showScenariosWithHazardsOption: ValuedSynthesisOption = {
 };
 
 /**
+ * Boolean option to toggle the visualization of the relationship graph.
+ */
+const showEdgesOption: ValuedSynthesisOption = {
+    synthesisOption: {
+        id: showEdgesID,
+        name: "Relationship Edges",
+        type: TransformationOptionType.CHECK,
+        initialValue: true,
+        currentValue: true,
+        values: [true, false],
+        category: filterCategory,
+    },
+    currentValue: true,
+};
+
+/**
  * Option to filter the node labels based on the aspect of the node.
  */
 const showLabelsOption: ValuedSynthesisOption = {
@@ -384,6 +401,7 @@ export class StpaSynthesisOptions extends SynthesisOptions {
                 showScenariosOption,
                 showScenariosWithHazardsOption,
                 showSafetyConstraintsOption,
+                showEdgesOption
             ]
         );
     }
@@ -421,6 +439,14 @@ export class StpaSynthesisOptions extends SynthesisOptions {
 
     getShowRelationshipGraph(): boolean {
         return this.getOption(showRelationshipGraphID)?.currentValue;
+    }
+
+    setShowEdges(value: boolean): void {
+        this.setOption(showEdgesID, value);
+    }
+
+    getShowEdges(): boolean {
+        return this.getOption(showEdgesID)?.currentValue;
     }
 
     setShowControlStructure(value: boolean): void {

--- a/extension/src-webview/stpa/helper-methods.ts
+++ b/extension/src-webview/stpa/helper-methods.ts
@@ -141,10 +141,11 @@ function getSuccNodes(edge: SEdgeImpl, elements: SModelElementImpl[]): void {
 function gettingOutgoingForSubcomponents(node: STPANode, elements: SModelElementImpl[]): void {
     // for sub-systemconstraints the parent node(s) should be highlighted as well
     if (isSubConstraint(node)) {
-        getSubConsParent(node, elements);
+        getSubConsParent(node, elements); // TODO: maybe change in the future, so that it works for all hierachy levels
     }
     // for sub-hazards the parent node(s) and its outgoing edges should be highlighted as well
     if (isSubHazard(node)) {
+        gettingOutgoingForSubcomponents(node.parent as STPANode, elements);
         elements.push(node.parent as STPANode);
         for (const port of (node.parent as STPANode).children.filter(child => child.type === PORT_TYPE && (child as PastaPort).side === PortSide.NORTH)) {
             for (const child of (node.parent as STPANode).parent.children) {

--- a/extension/src-webview/stpa/stpa-model.ts
+++ b/extension/src-webview/stpa/stpa-model.ts
@@ -39,6 +39,7 @@ export class ParentNode extends SNodeImpl {
     modelOrder: boolean;
     showBorder: boolean;
     static readonly DEFAULT_FEATURES = [connectableFeature, selectFeature, layoutContainerFeature, fadeFeature];
+    showEdges: boolean;
 }
 
 /**

--- a/extension/src-webview/stpa/stpa-views.tsx
+++ b/extension/src-webview/stpa/stpa-views.tsx
@@ -25,7 +25,7 @@ import { ColorStyleOption, DifferentFormsOption, FeedbackStyleOption, RenderOpti
 import { SendModelRendererAction } from '../snippets/actions';
 import { renderCollapseIcon, renderDiamond, renderEllipse, renderExpandIcon, renderHexagon, renderMirroredTriangle, renderOval, renderPentagon, renderRectangle, renderRectangleForNode, renderRoundedRectangle, renderTrapez, renderTriangle } from '../views-rendering';
 import { collectAllChildren } from './helper-methods';
-import { CSEdge, CSNode, CS_EDGE_TYPE, CS_INTERMEDIATE_EDGE_TYPE, CS_NODE_TYPE, EdgeType, ParentNode, STPAAspect, STPAEdge, STPANode, STPA_EDGE_TYPE, STPA_INTERMEDIATE_EDGE_TYPE } from './stpa-model';
+import { CSEdge, CSNode, CS_EDGE_TYPE, CS_INTERMEDIATE_EDGE_TYPE, CS_NODE_TYPE, EdgeType, PARENT_TYPE, ParentNode, STPAAspect, STPAEdge, STPANode, STPA_EDGE_TYPE, STPA_INTERMEDIATE_EDGE_TYPE } from './stpa-model';
 
 /** Determines if path/aspect highlighting is currently on. */
 let highlighting: boolean;
@@ -73,8 +73,18 @@ export class PolylineArrowEdgeView extends PolylineEdgeView {
         }
 
         // if an STPANode is selected, the components not connected to it should fade out
-        const hidden = (edge.type === STPA_EDGE_TYPE || edge.type === STPA_INTERMEDIATE_EDGE_TYPE) && highlighting && !(edge as STPAEdge).highlight;
-        // feedback edges in the control structure are possibly styled differently
+        // const hidden = (edge.type === STPA_EDGE_TYPE || edge.type === STPA_INTERMEDIATE_EDGE_TYPE) && highlighting && !(edge as STPAEdge).highlight;
+        // TODO check corresponding option
+        let hidden = false;
+        if (edge.parent.type === PARENT_TYPE && !(edge.parent as ParentNode).showEdges) {
+            hidden = (edge.type === STPA_EDGE_TYPE || edge.type === STPA_INTERMEDIATE_EDGE_TYPE) && !(edge as STPAEdge).highlight;
+            if (hidden) {
+                return <g/>;
+            }
+        } else {
+            hidden = (edge.type === STPA_EDGE_TYPE || edge.type === STPA_INTERMEDIATE_EDGE_TYPE) && highlighting && !(edge as STPAEdge).highlight;
+        }
+        // feedback edges in the control structure should be dashed
         const feedbackEdge = (edge.type === CS_EDGE_TYPE || edge.type === CS_INTERMEDIATE_EDGE_TYPE) && (edge as CSEdge).edgeType === EdgeType.FEEDBACK;
         // edges that represent missing edges should be highlighted
         const missing = (edge.type === CS_EDGE_TYPE || edge.type === CS_INTERMEDIATE_EDGE_TYPE) && (edge as CSEdge).edgeType === EdgeType.MISSING_FEEDBACK;
@@ -105,7 +115,16 @@ export class PolylineArrowEdgeView extends PolylineEdgeView {
 
     protected renderAdditionals(edge: SEdgeImpl, segments: Point[], context: RenderingContext): VNode[] {
         // if an STPANode is selected, the components not connected to it should fade out
-        const hidden = edge.type === STPA_EDGE_TYPE && highlighting && !(edge as STPAEdge).highlight;
+        // TODO check corresponding option
+        let hidden = false;
+        if (edge.parent.type === PARENT_TYPE && !(edge.parent as ParentNode).showEdges) {
+            hidden = edge.type === STPA_EDGE_TYPE && !(edge as STPAEdge).highlight;
+            if (hidden) {
+                return <g/>;
+            }
+        } else {
+            hidden = edge.type === STPA_EDGE_TYPE && highlighting && !(edge as STPAEdge).highlight;
+        }
 
         const forelastSegment = segments[segments.length - 2];
         const lastSegment = segments[segments.length - 1];


### PR DESCRIPTION
- Added a new Relationship Edges option.
- When disabled, edge spacing is removed so the diagram arranges more tightly.
- Edges are now initially displayed in a greyed-out state.