### PR TITLE
Added automatic filtering option for UCAs

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -219,7 +219,7 @@ The extension provides several diagram options to adjust the diagram.
 * Hierarchy: If this option is selected, subcomponents are drawn inside their parents. Otherwise this connection is shown by an edge from the subcomponent to its parent.
 * Group UCAs: UCAs can be grouped by their control action or their system component. Each group of UCAs has their own layer in the diagram.
 * Show Labels of: This option determines of which aspects the descriptions are shown in the diagram. If "Automatic" is selected, the shown labels are determined by the cursor position. In most cases the labels of the aspect which must be referenced by the currently modified aspect are shown. When writing Hazards also the Hazard descriptions are shown.
-* Filter UCA by Control Action: The UCAs can be filtered such that only UCAs for a certain control action are shown making the diagram smaller and clearer.
+* Filter UCA by Control Action: The UCAs can be filtered such that only UCAs for a certain control action are shown making the diagram smaller and clearer. If "automatic" is selected, the UCAs shown depend on the cursor position. In this mode, all UCAs linked to the control action of the element currently being worked on are displayed.
 * Show x: When selected the specified graph/aspect is shown, otherwise it is hidden.
 
 

--- a/extension/src-language-server/stpa/diagram/filtering.ts
+++ b/extension/src-language-server/stpa/diagram/filtering.ts
@@ -29,6 +29,7 @@ import {
     SystemResponsibilities,
 } from "../../generated/ast.js";
 import { StpaSynthesisOptions } from "./stpa-synthesis-options.js";
+import { getCurrentElement } from "./utils.js"
 
 /**
  * Needed to work on a filtered model without changing the original model.
@@ -69,29 +70,34 @@ export function filterModel(model: Model, options: StpaSynthesisOptions): Custom
             !options.getShowSysCons() || !options.getShowRespsCons() ? [] : model.responsibilities;
 
         // filter UCAs by the filteringUCA option
+        const currentControlAction = getCurrentElement(model)
         newModel.allUCAs = !options.getShowUCAs()
             ? []
             : model.allUCAs?.filter(
                   (allUCA) =>
                       allUCA.system.ref?.name + "." + allUCA.action.ref?.name === options.getFilteringUCAs() ||
-                      options.getFilteringUCAs() === "all UCAs"
+                      options.getFilteringUCAs() === "all UCAs" || 
+                      (options.getFilteringUCAs() === "automatic" &&
+                      allUCA.system.ref?.name + "." + allUCA.action.ref?.name === currentControlAction)
               );
         newModel.rules = !options.getShowUCAs()
             ? []
             : model.rules?.filter(
                   (rule) =>
                       rule.system.ref?.name + "." + rule.action.ref?.name === options.getFilteringUCAs() ||
-                      options.getFilteringUCAs() === "all UCAs"
+                      options.getFilteringUCAs() === "all UCAs" ||
+                      (options.getFilteringUCAs() === "automatic" &&
+                      rule.system.ref?.name + "." + rule.action.ref?.name === currentControlAction)
               );
         newModel.controllerConstraints =
             !options.getShowUCAs() || !options.getShowContCons()
                 ? []
                 : model.controllerConstraints?.filter(
                       (cons) =>
-                          cons.refs[0].ref?.$container.system.ref?.name +
-                              "." +
-                              cons.refs[0].ref?.$container.action.ref?.name ===
-                              options.getFilteringUCAs() || options.getFilteringUCAs() === "all UCAs"
+                          cons.refs[0].ref?.$container.system.ref?.name + "." + cons.refs[0].ref?.$container.action.ref?.name === options.getFilteringUCAs() || 
+                          options.getFilteringUCAs() === "all UCAs" || 
+                          (options.getFilteringUCAs() === "automatic" &&
+                          cons.refs[0].ref?.$container.system.ref?.name + "." + cons.refs[0].ref?.$container.action.ref?.name === currentControlAction) 
                   );
 
         // remaining scenarios must be saved to filter safety constraints
@@ -102,11 +108,10 @@ export function filterModel(model: Model, options: StpaSynthesisOptions): Custom
                   if (
                       (!scenario.uca && options.getShowScenariosWithHazard()) ||
                       (scenario.uca && options.getShowUCAs() &&
-                          (scenario.uca?.ref?.$container.system.ref?.name +
-                              "." +
-                              scenario.uca?.ref?.$container.action.ref?.name ===
-                              options.getFilteringUCAs() ||
-                              options.getFilteringUCAs() === "all UCAs"))
+                          (scenario.uca?.ref?.$container.system.ref?.name + "." + scenario.uca?.ref?.$container.action.ref?.name === options.getFilteringUCAs() ||
+                          options.getFilteringUCAs() === "all UCAs" ||
+                          options.getFilteringUCAs() === "automatic" &&
+                          scenario.uca?.ref?.$container.system.ref?.name + "." + scenario.uca?.ref?.$container.action.ref?.name === currentControlAction))
                   ) {
                       remainingScenarios.add(scenario.name);
                       return true;
@@ -134,6 +139,7 @@ export function filterModel(model: Model, options: StpaSynthesisOptions): Custom
 function setFilterUCAOption(allUCAs: ActionUCAs[], rules: Rule[], options: StpaSynthesisOptions): void {
     const set = new Set<string>();
     set.add("all UCAs");
+    set.add("automatic");
     // collect all available control actions
     allUCAs?.forEach((uca) => {
         if (!set.has(uca.system.ref?.name + "." + uca.action.ref?.name)) {

--- a/extension/src-language-server/stpa/diagram/stpa-synthesis-options.ts
+++ b/extension/src-language-server/stpa/diagram/stpa-synthesis-options.ts
@@ -226,7 +226,7 @@ const filteringOfUCAs: ValuedSynthesisOption = {
         name: "Filter UCAs by Control Action",
         type: TransformationOptionType.DROPDOWN,
         currentId: "all UCAs",
-        availableValues: [{ displayName: "all UCAs", id: "all UCAs" }],
+        availableValues: [{ displayName: "all UCAs", id: "all UCAs" }, { displayName: "automatic", id: "automatic"}],
         initialValue: "all UCAs",
         currentValue: "all UCAs",
         values: [],


### PR DESCRIPTION
- Added a new automatic filtering option for UCA filtering
- When enabled all UCAs linked to the control action of the element currently being worked on are displayed.
- If the element, that is currently being worked on, has no control action, no UCAs are displayed.